### PR TITLE
build(deps): bump node from v16 to v20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.2 AS base
+FROM node:20.19.0 AS base
 WORKDIR /app
 
 FROM base AS node_modules


### PR DESCRIPTION
v20 is the previous Long Term Support release. v16 is no longer supported.