### PR TITLE
ci(js-build): stop using deprecated output command

### DIFF
--- a/.github/workflows/js-build.yml
+++ b/.github/workflows/js-build.yml
@@ -74,7 +74,7 @@ jobs:
           then
             REF_NAME=pr-${PR_NUM}
           fi
-          echo "::set-output name=tag-name::${REF_NAME}-$(date +%Y)-${SECONDS_HEX}"
+          echo "tag-name=${REF_NAME}-$(date +%Y)-${SECONDS_HEX}" >> $GITHUB_OUTPUT
       - name: Build and push production container image
         if: ${{ github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: docker/build-push-action@v6


### PR DESCRIPTION
We're seeing the following warning:
>Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
